### PR TITLE
Misspelled word LAB_02_queries_using_serverless_sql_pools.md

### DIFF
--- a/Instructions/Labs/LAB_02_queries_using_serverless_sql_pools.md
+++ b/Instructions/Labs/LAB_02_queries_using_serverless_sql_pools.md
@@ -232,7 +232,7 @@ You decide to create an external table that connects to the external data source
 
 Let's create a view to wrap a SQL query. Views allow you to reuse queries and are needed if you want to use tools, such as Power BI, in conjunction with serverless SQL pools.
 
-1. In the **Data** hub, on the **Linked** tab, in the **Azure Data Lake Storage Gen2/asaworkspace*xxxxxx*/ wwi-02** container, avigate to the **customer-info** folder. Then right-click the **customerinfo.csv** file, select **New SQL script**, and then **Select TOP 100 rows**.
+1. In the **Data** hub, on the **Linked** tab, in the **Azure Data Lake Storage Gen2/asaworkspace*xxxxxx*/ wwi-02** container, navigate to the **customer-info** folder. Then right-click the **customerinfo.csv** file, select **New SQL script**, and then **Select TOP 100 rows**.
 
     ![The Data hub is displayed with the options highlighted.](images/customerinfo-select-rows.png "Select TOP 100 rows")
 


### PR DESCRIPTION
Lab2
Ex 1, Task 4, Step 1 - instructions have word navigate misspelled.

Ex 2 Task 3 Steps 6 and 8 - the process for assigning members to a role has changed.  Instructions need to be updated to match the current interface in the Azure portal.

Ex 2 Task 4 Step 2 - the steps for modifying an acl has changed - you must select +add principal, then add the object id in the search box, select the principal name and select SELECT, to modify permissions for the Default you must select the tab and perform the steps again.


-
-
-